### PR TITLE
Fix universe inconsistency issue in FoldCTree

### DIFF
--- a/theories/Eq/SSim.v
+++ b/theories/Eq/SSim.v
@@ -1047,7 +1047,7 @@ Section Proof_Rules.
     With invisible schedules, they are always equivalent: neither of them
     produce any challenge for the other.
 |*)
-  Lemma spinS_gen_nonempty : forall {Z Y D F} {L: rel (label E) (label F)} `{HasStuck': B0 -< D}
+  Lemma spinS_gen_nonempty : forall {Z X Y D F} {L: rel (label E) (label F)} `{HasStuck': B0 -< D}
                                (c: C X) (c': C Y) (x: X) (y: Y),
       L tau tau ->
       ssim L (@spinS_gen E C Z X c) (@spinS_gen F C Z Y c').

--- a/theories/Interp/FoldCTree.v
+++ b/theories/Interp/FoldCTree.v
@@ -26,7 +26,6 @@ Open Scope ctree_scope.
     For now, we simply specialize results to specific [M]s.
  *)
 
-Unset Universe Checking.
 Theorem ssim_interp_h {E F1 F2 C D1 D2 X Y}
   `{HasB0 : B0 -< D1} `{HasB1 : B1 -< D1} `{HasB0' : B0 -< D2} `{HasB1' : B1 -< D2}
   `{HC1 : C -< D1} `{HC2 : C -< D2}
@@ -47,9 +46,8 @@ Proof.
     apply equ_vis_invT in H1 as ?. subst.
     eapply ssim_clo_bind_gen with (R0 := eq).
     + red. reflexivity.
-    + admit. (* FIXME universe inconsistency *)
-      (*eapply weq_ssim. apply update_val_rel_update_val_rel.
-      apply equ_vis_invE in H1 as [<- ?]. apply H0.*)
+    + eapply weq_ssim. apply update_val_rel_update_val_rel.
+      apply equ_vis_invE in H1 as [<- ?]. apply H0.
     + intros. step. apply step_ss_ret. constructor.
       apply equ_vis_invE in H1 as [<- ?]. subst. apply H1.
   - unfold CTree.map. setoid_rewrite bind_branch.
@@ -58,8 +56,7 @@ Proof.
     destruct vis.
     + step. apply step_ss_brS. intros. exists x0. step. apply step_ss_ret. constructor. apply H1. right; auto. 3: apply H. all: intros H2; inversion H2.
     + step. apply step_ss_brD. intros. exists x0. apply step_ss_ret. constructor. apply H1.
-Admitted.
-Set Universe Checking.
+Qed.
 
 Section FoldCTree.
 

--- a/theories/Logic/ctl_yannick.v
+++ b/theories/Logic/ctl_yannick.v
@@ -732,7 +732,7 @@ Module Termination.
     econstructor.
 Qed.
 
-End Termination
+End Termination.
  
                   
 Module Scheduling.


### PR DESCRIPTION
I haven't been able to `dune build` the entire thing[^1] bc my laptop is too pathetic so you should check this yourselves but I've built enough portions that I'm fairly confident this should fix the universe inconsistency issue in FoldCTree.

(Unfortunately for me (but fortunately for y'all) it wasn't an instance where something really needed to be polymorphic but rather that `C` was applied to `X` when you have `ctree E C X`. It would probably help prevent future issues if you changed the definition of ctrees to enforce that the universe level of `ctree E C X` and of `X` be exactly the same...)

[^1]: Is there a `dune build` GH action for PRs? That'd be v handy