### PR TITLE
Generalize `refine_equ` congruence

### DIFF
--- a/theories/Interp/Fold.v
+++ b/theories/Interp/Fold.v
@@ -122,8 +122,8 @@ Proof.
     apply CH. apply REL.
 Qed.
 
-#[global] Instance refine_equ {E C X} h:
-  Proper (equ eq ==> @equ E C X X eq) (@refine E C _ _ _ _ _ _ _ h X).
+#[global] Instance refine_equ {E C D X} (h : C ~> ctree E D):
+  Proper (equ eq ==> @equ E D X X eq) (@refine E C _ _ _ _ _ _ _ h X).
 Proof.
   cbn.
   coinduction R CH.


### PR DESCRIPTION
`refine_equ` currently only applies when the refinement does not change the branching, structure. This PR fixes this by generalizing the type, no changes to the proof are required as it still goes through with the new type.